### PR TITLE
Allow user to vote on each article

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -110,3 +110,17 @@ header {
 .comment-body {
     margin: 8px 0;
 }
+
+.vote-block {
+    display: flex;
+}
+
+.vote-block button {
+    width: 25px;
+    height: 25px;
+    padding: 0;
+}
+
+.vote-block * {
+    margin-right: 8px;
+}

--- a/src/components/ArticleBody.jsx
+++ b/src/components/ArticleBody.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
-import { getArticleById } from "../utils/api";
+import { getArticleById, updateArticleVotes } from "../utils/api";
 import Loading from "./Loading";
+import VoteCounter from "./VoteCounter";
 
 function ArticleBody({ article_id }) {
     const [article, setArticle] = useState(null);
@@ -27,7 +28,7 @@ function ArticleBody({ article_id }) {
 
             <img src={article.article_img_url} alt="current article" />
             <p>{article.body}</p>
-            <div>Votes: {article.votes}</div>
+            <VoteCounter article_id={article_id} votes={article.votes} voteUpdater={updateArticleVotes}/>
         </section>
     );
 }

--- a/src/components/VoteCounter.jsx
+++ b/src/components/VoteCounter.jsx
@@ -1,0 +1,41 @@
+import { useState } from "react";
+
+function VoteCounter({ article_id, votes, voteUpdater }) {
+    const [currentVotes, setCurrentVotes] = useState(votes);
+    const [responseMsg, setResponseMsg] = useState(null);
+    const [disableButtons, setDisableButtons] = useState(false);
+
+    function updateVote(voteChange) {
+        setDisableButtons(true);
+        setResponseMsg("Waiting for confirmation");
+        setCurrentVotes((currVotes) => currVotes + voteChange);
+
+        voteUpdater(article_id, voteChange)
+            .then((serverVotes) => {
+                setResponseMsg("Your vote has been counted");
+                setCurrentVotes(() => serverVotes);
+            })
+            .catch((error) => {
+                setResponseMsg("Your vote was lost in transit");
+                setCurrentVotes((currentVotes) => currentVotes - voteChange);
+            })
+            .finally(() => {
+                setDisableButtons(false);
+            });
+    }
+
+    return (
+        <section className="vote-block">
+            <div>Votes: {currentVotes}</div>
+            <button disabled={disableButtons} onClick={() => updateVote(1)}>
+                ⬆
+            </button>
+            <button disabled={disableButtons} onClick={() => updateVote(-1)}>
+                ⬇
+            </button>
+            {responseMsg ? <div>{responseMsg}</div> : null}
+        </section>
+    );
+}
+
+export default VoteCounter;

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -19,3 +19,11 @@ export function getCommentsByArticleId(article_id) {
         return response.data.comments;
     });
 }
+
+export function updateArticleVotes(article_id, voteChange) {
+    return api
+        .patch(`/articles/${article_id}`, { inc_votes: voteChange })
+        .then((response) => {
+            return response.data.article.votes;
+        });
+}


### PR DESCRIPTION
Adds buttons next to the vote count which allow the user to increment or decrement the vote total. The user may do this as many times as they want.

The buttons are disabled right after one of them is pressed. They are re-enabled when a response is returned from the API or an error occurs.

Next to the buttons, a message shows up which tells the user what the current state of the vote request is.

The vote count is updated optimistically. The buttons are disabled after each press to prevent multiple concurrent requests from the same user causing the vote count to change multiple times on slower connections.