### PR TITLE
Add delete comment button to `CommentCard`

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -10,6 +10,12 @@ header {
     margin: 0 auto;
 }
 
+.simple-flex-row {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+}
+
 .horizontal-text {
     display: flex;
     justify-content: space-between;
@@ -111,6 +117,15 @@ header {
 
 .comment-body {
     margin: 8px 0;
+}
+
+.comment-delete-button {
+    padding: 4px;
+    margin: 8px 8px 0 0;
+}
+
+.comment-delete-msg {
+    margin: 8px 0 0 0;
 }
 
 .vote-block {

--- a/src/components/ArticleBody.jsx
+++ b/src/components/ArticleBody.jsx
@@ -28,7 +28,11 @@ function ArticleBody({ article_id }) {
 
             <img src={article.article_img_url} alt="current article" />
             <p>{article.body}</p>
-            <VoteCounter article_id={article_id} votes={article.votes} voteUpdater={updateArticleVotes}/>
+            <VoteCounter
+                subject_id={article_id}
+                votes={article.votes}
+                voteUpdater={updateArticleVotes}
+            />
         </section>
     );
 }

--- a/src/components/CommentCard.jsx
+++ b/src/components/CommentCard.jsx
@@ -1,13 +1,71 @@
+import { useContext, useState } from "react";
 import { formatDateTime } from "../utils/text";
+import { deleteComment, updateCommentVotes } from "../utils/api";
+import VoteCounter from "./VoteCounter";
+import { UserContext } from "../contexts/UserContext";
 
 function CommentCard({ comment }) {
-    const { author, created_at, body, votes } = comment;
+    const { comment_id, author, created_at, body, votes } = comment;
+
+    const [deleted, setDeleted] = useState(false);
+    const [disabledButton, setDisabledButton] = useState(false);
+    const [errorMsg, setErrorMsg] = useState("");
+
+    const { user } = useContext(UserContext);
+
+    function deleteCommentHandler(event) {
+        setDisabledButton(true);
+        setErrorMsg("");
+
+        deleteComment(comment_id)
+            .then(() => {
+                setDeleted(true);
+            })
+            .catch((error) => {
+                setErrorMsg("Could not delete comment");
+            })
+            .finally(() => {
+                setDisabledButton(false);
+            });
+    }
+
+    function renderDeleteButton() {
+        if (author === user) {
+            return (
+                <div className="simple-flex-row">
+                    <button
+                        className="comment-delete-button"
+                        disabled={disabledButton}
+                        onClick={deleteCommentHandler}
+                    >
+                        Delete Comment
+                    </button>
+                    <div className="comment-delete-msg">{errorMsg}</div>
+                </div>
+            );
+        }
+    }
+
+    if (deleted) {
+        return (
+            <section className="comment-card">
+                <div>This comment has been deleted</div>
+            </section>
+        );
+    }
 
     return (
         <section className="comment-card">
-            <div>{author} - {formatDateTime(created_at)}</div>
+            <div>
+                {author} - {formatDateTime(created_at)}
+            </div>
             <div className="comment-body">{body}</div>
-            <div>Votes: {votes}</div>
+            <VoteCounter
+                subject_id={comment_id}
+                votes={votes}
+                voteUpdater={updateCommentVotes}
+            />
+            {renderDeleteButton()}
         </section>
     );
 }

--- a/src/components/CommentCard.jsx
+++ b/src/components/CommentCard.jsx
@@ -7,24 +7,24 @@ import { UserContext } from "../contexts/UserContext";
 function CommentCard({ comment }) {
     const { comment_id, author, created_at, body, votes } = comment;
 
-    const [deleted, setDeleted] = useState(false);
+    const [deleted, setDeleted] = useState("");
     const [disabledButton, setDisabledButton] = useState(false);
     const [errorMsg, setErrorMsg] = useState("");
 
     const { user } = useContext(UserContext);
 
     function deleteCommentHandler(event) {
+        setDeleted("Awaiting confirmation");
         setDisabledButton(true);
         setErrorMsg("");
 
         deleteComment(comment_id)
             .then(() => {
-                setDeleted(true);
+                setDeleted("This comment has been deleted");
             })
             .catch((error) => {
+                setDeleted("");
                 setErrorMsg("Could not delete comment");
-            })
-            .finally(() => {
                 setDisabledButton(false);
             });
     }
@@ -49,7 +49,7 @@ function CommentCard({ comment }) {
     if (deleted) {
         return (
             <section className="comment-card">
-                <div>This comment has been deleted</div>
+                <div>{deleted}</div>
             </section>
         );
     }

--- a/src/components/VoteCounter.jsx
+++ b/src/components/VoteCounter.jsx
@@ -1,18 +1,17 @@
 import { useState } from "react";
 
-function VoteCounter({ article_id, votes, voteUpdater }) {
+function VoteCounter({ subject_id, votes, voteUpdater }) {
     const [currentVotes, setCurrentVotes] = useState(votes);
     const [responseMsg, setResponseMsg] = useState(null);
     const [disableButtons, setDisableButtons] = useState(false);
 
     function updateVote(voteChange) {
         setDisableButtons(true);
-        setResponseMsg("Waiting for confirmation");
+        setResponseMsg(null);
         setCurrentVotes((currVotes) => currVotes + voteChange);
 
-        voteUpdater(article_id, voteChange)
+        voteUpdater(subject_id, voteChange)
             .then((serverVotes) => {
-                setResponseMsg("Your vote has been counted");
                 setCurrentVotes(() => serverVotes);
             })
             .catch((error) => {

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -28,8 +28,22 @@ export function updateArticleVotes(article_id, voteChange) {
         });
 }
 
+export function updateCommentVotes(comment_id, voteChange) {
+    return api
+        .patch(`/comments/${comment_id}`, { inc_votes: voteChange })
+        .then((response) => {
+            return response.data.comment.votes;
+        });
+}
+
 export function postComment(article_id, username, body) {
-    return api.post(`/articles/${article_id}/comments`, {username, body}).then((response) => {
-        return response.data.comment;
-    })
+    return api
+        .post(`/articles/${article_id}/comments`, { username, body })
+        .then((response) => {
+            return response.data.comment;
+        });
+}
+
+export function deleteComment(comment_id) {
+    return api.delete(`/comments/${comment_id}`);
 }


### PR DESCRIPTION
Added a delete comment button to the `CommentCard` component. When pressed, the contents of the component are replaced with simple text informing the user that their request has been sent. The message changes to confirmation of the comment being deleted once a successful response has been received.

The purpose of the awaiting message is to prevent the user from using the vote buttons after pressing the delete button.

If an error occurs, the comment is returned to how it was before, with a message next to the delete button informing the user that the delete request did not succeed.

When the page is reloaded, the deleted comment cards are no longer visible.