### PR TITLE
Add topics page and filter articles by topic

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -32,6 +32,22 @@ header {
     min-width: 125px;
 }
 
+.navbar a {
+    margin: 0 8px;
+}
+
+.topic-list {
+    list-style-type: none;
+    padding: 0;
+    max-width: 500px;
+    margin: 0 auto;
+}
+
+.topic-card {
+    border: 2px solid;
+    margin: 16px 0;
+}
+
 .article-list {
     display: flex;
     flex-direction: row;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,6 +3,7 @@ import "./App.css";
 import ArticlesQuery from "./components/ArticlesQuery";
 import Header from "./components/Header";
 import ArticlePage from "./components/ArticlePage";
+import TopicsPage from "./components/TopicsPage";
 
 function App() {
     return (
@@ -15,6 +16,7 @@ function App() {
                         path="/articles/:article_id"
                         element={<ArticlePage />}
                     />
+                    <Route path="/topics" element={<TopicsPage />} />
                 </Routes>
             </main>
         </>

--- a/src/components/ArticleList.jsx
+++ b/src/components/ArticleList.jsx
@@ -3,11 +3,11 @@ import { getArticles } from "../utils/api";
 import ArticleCard from "./ArticleCard";
 import Loading from "./Loading";
 
-function ArticleList() {
+function ArticleList({ searchParams }) {
     const [articles, setArticles] = useState(null);
 
     useEffect(() => {
-        getArticles()
+        getArticles(searchParams)
             .then((articles) => {
                 setArticles(articles);
             })

--- a/src/components/ArticlesQuery.jsx
+++ b/src/components/ArticlesQuery.jsx
@@ -1,7 +1,10 @@
+import { useSearchParams } from "react-router-dom";
 import ArticleList from "./ArticleList";
 
 function ArticlesQuery() {
-    return <ArticleList />;
+    const [searchParams, setSearchParams] = useSearchParams();
+    
+    return <ArticleList searchParams={searchParams} />;
 }
 
 export default ArticlesQuery;

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -4,8 +4,9 @@ function Header() {
     return (
         <header>
             <h1>NC News</h1>
-            <nav>
+            <nav className="navbar">
                 <Link to="/articles">Articles</Link>
+                <Link to="/topics">Topics</Link>
             </nav>
         </header>
     );

--- a/src/components/TopicCard.jsx
+++ b/src/components/TopicCard.jsx
@@ -1,0 +1,16 @@
+import { Link } from "react-router-dom";
+
+function TopicCard({ topic }) {
+    const { slug, description } = topic;
+
+    return (
+        <section className="topic-card">
+            <Link to={`/articles?topic=${slug}`}>
+                <h2>{slug}</h2>
+            </Link>
+            <p>{description}</p>
+        </section>
+    );
+}
+
+export default TopicCard;

--- a/src/components/TopicsList.jsx
+++ b/src/components/TopicsList.jsx
@@ -1,0 +1,34 @@
+import { useEffect, useState } from "react";
+import { getTopics } from "../utils/api";
+import TopicCard from "./TopicCard";
+import Loading from "./Loading";
+
+function TopicsList() {
+    const [topics, setTopics] = useState(null);
+
+    useEffect(() => {
+        getTopics()
+            .then((topics) => {
+                setTopics(topics);
+            })
+            .catch((error) => {
+                console.log(error);
+            });
+    }, []);
+
+    if (topics === null) {
+        return <Loading />;
+    }
+
+    return (
+        <ul className="topic-list">
+            {topics.map((topic) => {
+                return <li key={topic.slug}>
+                    <TopicCard topic={topic} />
+                </li>;
+            })}
+        </ul>
+    );
+}
+
+export default TopicsList;

--- a/src/components/TopicsPage.jsx
+++ b/src/components/TopicsPage.jsx
@@ -1,0 +1,7 @@
+import TopicsList from "./TopicsList";
+
+function TopicsPage() {
+    return <TopicsList />;
+}
+
+export default TopicsPage;

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -1,9 +1,17 @@
 import axios from "axios";
+import { linkWithParams } from "./api_utils";
 
 const api = axios.create({ baseURL: "https://nc-news-moag.onrender.com/api" });
 
-export function getArticles() {
-    return api.get("/articles").then((response) => {
+export function getTopics() {
+    return api.get("/topics").then((response) => {
+        return response.data.topics;
+    });
+}
+
+export function getArticles(searchParams) {
+    const link = linkWithParams("/articles", searchParams);
+    return api.get(link).then((response) => {
         return response.data.articles;
     });
 }

--- a/src/utils/api_utils.js
+++ b/src/utils/api_utils.js
@@ -1,0 +1,13 @@
+export function linkWithParams(link, searchParams) {
+    if (searchParams.size === 0) {
+        return link;
+    }
+
+    let queryStrings = [];
+
+    for (let [key, value] of searchParams.entries()) {
+        queryStrings.push(`${key}=${value}`);
+    }
+
+    return link + "?" + queryStrings.join("&");
+}


### PR DESCRIPTION
Added the topics page which can be accessed by clicking "Topics" in the navigation bar.

This page shows a link for each topic in the database. Clicking this link will redirect the user to the articles page with a search query applied for that particular topic.

The resulting articles page only shows articles for the given topic. The URL of this page includes the search query e.g. `/articles?topic=coding`. Using this link directly provides the filtered articles page.